### PR TITLE
KAN-464 feat: 주문알림-레디스 메시지리스너 컨테이너 구성클래스 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/src/main/java/com/yeonieum/orderservice/global/config/RedisConfig.java
+++ b/src/main/java/com/yeonieum/orderservice/global/config/RedisConfig.java
@@ -1,0 +1,52 @@
+package com.yeonieum.orderservice.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword("your-password");
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisOperations<String, Long> orderEventRedisOperations(RedisConnectionFactory redisConnectionFactory) {
+        final Jackson2JsonRedisSerializer<Long> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Long.class);
+        final RedisTemplate<String, Long> orderEventRedisTemplate = new RedisTemplate<>();
+
+        orderEventRedisTemplate.setConnectionFactory(redisConnectionFactory);
+        orderEventRedisTemplate.setKeySerializer(RedisSerializer.string());
+        orderEventRedisTemplate.setValueSerializer(jsonRedisSerializer);
+        orderEventRedisTemplate.setHashKeySerializer(RedisSerializer.string());
+        orderEventRedisTemplate.setHashValueSerializer(jsonRedisSerializer);
+        return orderEventRedisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+        final RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
+        redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
+        return redisMessageListenerContainer;
+    }
+}


### PR DESCRIPTION
[![KAN-464](https://badgen.net/badge/JIRA/KAN-464/blue?icon=jira)](https://jira.company.com/browse/KAN-464) [![PR-20](https://badgen.net/badge/Preview/PR-20/blue)](https://pr-20.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 레디스 메시지리스너 컨테이너 구성클래스 정의

## #️⃣관련 이슈

- Close#{464}

## 📝세부 작업 내용

- [x] 레디스 의존성 추가
- [x] 레디스 메시지리스너 컨테이너 구성클래스 정의[SSE주문알림을 위한 pub/sub 인프라 구축]


## 💬참고 사항

[KAN-464]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ