### PR TITLE
KAN-494 feat: 출고 상태변경 일괄 처리 서비스

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/release/dto/ReleaseRequest.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/release/dto/ReleaseRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class ReleaseRequest {
 
@@ -12,6 +13,13 @@ public class ReleaseRequest {
     @NoArgsConstructor
     public static class OfUpdateReleaseStatus {
         String orderId;
+        ReleaseStatusCode releaseStatusCode;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class OfBulkUpdateReleaseStatus  {
+        List<String> orderIds;
         ReleaseStatusCode releaseStatusCode;
     }
 

--- a/src/main/java/com/yeonieum/orderservice/web/controller/ReleaseController.java
+++ b/src/main/java/com/yeonieum/orderservice/web/controller/ReleaseController.java
@@ -61,7 +61,7 @@ public class ReleaseController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "출고 상태 변경 실패")
     })
     @PatchMapping("/status")
-    public ResponseEntity<ApiResponse> changeOrderStatus(@RequestBody ReleaseRequest.OfUpdateReleaseStatus updateStatus) {
+    public ResponseEntity<ApiResponse> changeReleaseStatus(@RequestBody ReleaseRequest.OfUpdateReleaseStatus updateStatus) {
         String Role = "CUSTOMER";
         if(!releaseStatusPolicy.getReleaseStatusPermission().get(updateStatus.getReleaseStatusCode()).contains(Role)) {
             throw new RuntimeException("접근권한이 없습니다.");
@@ -98,6 +98,25 @@ public class ReleaseController {
     public ResponseEntity<ApiResponse> changeReleaseHoldMemo(@RequestBody ReleaseRequest.OfHoldMemo updateHoldMemo) {
 
         releaseService.changeReleaseHoldMemo(updateHoldMemo);
+        return new ResponseEntity<>(ApiResponse.builder()
+                .result(null)
+                .successCode(SuccessCode.UPDATE_SUCCESS)
+                .build(), HttpStatus.OK);
+    }
+
+    @Operation(summary = "출고상태 일괄 변경 요청", description = "고객이 상품의 출고상태를 일괄 변경 요청합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "출고 상태 일괄 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "출고 상태 일괄 변경 실패")
+    })
+    @PatchMapping("/bulk-status")
+    public ResponseEntity<ApiResponse> changeBulkReleaseStatus(@RequestBody ReleaseRequest.OfBulkUpdateReleaseStatus updateStatus) {
+        String Role = "CUSTOMER";
+        if(!releaseStatusPolicy.getReleaseStatusPermission().get(updateStatus.getReleaseStatusCode()).contains(Role)) {
+            throw new RuntimeException("접근권한이 없습니다.");
+        }
+
+        releaseService.changeBulkReleaseStatus(updateStatus);
         return new ResponseEntity<>(ApiResponse.builder()
                 .result(null)
                 .successCode(SuccessCode.UPDATE_SUCCESS)


### PR DESCRIPTION
[![KAN-494](https://badgen.net/badge/JIRA/KAN-494/blue?icon=jira)](https://jira.company.com/browse/KAN-494) [![PR-34](https://badgen.net/badge/Preview/PR-34/blue)](https://pr-34.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 출고 상태변경 일괄 처리 서비스

## #️⃣관련 이슈

- Close#{494}

## 📝세부 작업 내용

- [x] 출고 상태변경 일괄 처리 서비스

## 💬참고 사항

- 다수의 상품의 출고 상태를 일괄적으로 변경할 수 있습니다.
  - (출고 대기, 출고 보류) -> 출고 완료
  - 출고대기 -> 출고 보류

[KAN-494]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ