### PR TITLE
KAN-497 feat: 주문 상태변경 일괄 처리 서비스

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/delivery/entity/Delivery.java
@@ -25,7 +25,7 @@ public class Delivery {
     @JoinColumn(name = "delivery_status_id", nullable = false)
     private DeliveryStatus deliveryStatus;
 
-    @Column(name = "shipment_number", nullable = false)
+    @Column(name = "shipment_number")
     private String shipmentNumber;
 }
 

--- a/src/main/java/com/yeonieum/orderservice/domain/order/dto/request/OrderRequest.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/order/dto/request/OrderRequest.java
@@ -32,6 +32,13 @@ public class OrderRequest {
 
     @Getter
     @NoArgsConstructor
+    public static class OfBulkUpdateOrderStatus {
+        List<String> orderIds;
+        OrderStatusCode orderStatusCode;
+    }
+
+    @Getter
+    @NoArgsConstructor
     public static class OfUpdateProductOrderStatus {
         String orderId;
         Long productId;

--- a/src/main/java/com/yeonieum/orderservice/domain/regularorder/entity/RegularDeliveryApplication.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/regularorder/entity/RegularDeliveryApplication.java
@@ -65,6 +65,9 @@ public class RegularDeliveryApplication {
     @Column(name = "ordered_product_count", nullable = false)
     private int orderedProductCount;
 
+    @Column(name = "next_delivery_date", nullable = false)
+    private LocalDate nextDeliveryDate;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "regular_delivery_status_id", nullable = false)
     private RegularDeliveryStatus regularDeliveryStatus;

--- a/src/main/java/com/yeonieum/orderservice/domain/release/service/ReleaseService.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/release/service/ReleaseService.java
@@ -250,7 +250,6 @@ public class ReleaseService {
      * @throws RuntimeException 주문 상태 트랜지션 룰 위반일 경우
      * @return
      */
-    @Transactional
     public void updateOrderAndDeliveryStatus(OrderDetail orderDetail, ReleaseStatusCode requestedStatusCode) {
         OrderStatus newOrderStatus;
 
@@ -261,10 +260,10 @@ public class ReleaseService {
             case RELEASE_COMPLETED:
                 if (orderDetail.getOrderStatus().getStatusName() != OrderStatusCode.SHIPPED) {
                     // 출고 완료 상태일 경우, 배송 시작 처리
-                    Delivery.builder()
+                    deliveryRepository.save(Delivery.builder()
                             .orderDetail(orderDetail)
                             .deliveryStatus(deliveryStatusRepository.findByStatusName(DeliveryStatusCode.SHIPPED))
-                            .build();
+                            .build());
 
                     // 주문 상태를 배송 시작으로 변경
                     newOrderStatus = orderStatusRepository.findByStatusName(OrderStatusCode.SHIPPED);

--- a/src/main/java/com/yeonieum/orderservice/web/controller/OrderDetailController.java
+++ b/src/main/java/com/yeonieum/orderservice/web/controller/OrderDetailController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/order")
@@ -121,6 +120,25 @@ public class OrderDetailController {
         String memberId = "컨텍스트에서 가져올 예정";
         orderProcessService.placeOrder(creationRequest, memberId);
         notificationService.sendEventMessage(creationRequest.getCustomerId());
+        return new ResponseEntity<>(ApiResponse.builder()
+                .result(null)
+                .successCode(SuccessCode.UPDATE_SUCCESS)
+                .build(), HttpStatus.OK);
+    }
+
+    @Operation(summary = "주문상태 일괄 변경 요청", description = "고객이 상품의 주문상태를 일괄 변경 요청합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "주문 상태 일괄 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "주문 상태 일괄 변경 실패")
+    })
+    @PatchMapping("/bulk-status")
+    public ResponseEntity<ApiResponse> changeBulkOrderStatus(@RequestBody OrderRequest.OfBulkUpdateOrderStatus updateStatus) {
+        String Role = "CUSTOMER";
+        if(!orderStatusPolicy.getOrderStatusPermission().get(updateStatus.getOrderStatusCode()).contains(Role)) {
+            throw new RuntimeException("접근권한이 없습니다.");
+        }
+
+        orderProcessService.changeBulkOrderStatus(updateStatus);
         return new ResponseEntity<>(ApiResponse.builder()
                 .result(null)
                 .successCode(SuccessCode.UPDATE_SUCCESS)


### PR DESCRIPTION
[![KAN-497](https://badgen.net/badge/JIRA/KAN-497/blue?icon=jira)](https://jira.company.com/browse/KAN-497) [![PR-35](https://badgen.net/badge/Preview/PR-35/blue)](https://pr-35.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 주문 상태변경 일괄처리 구현

## #️⃣관련 이슈

- Close#{497}

## 📝세부 작업 내용

- [x] 주문 상태변경 일괄 처리 구현

## 💬참고 사항

- 고객은 주문 상태변경을 일괄적으로 변경할 수 있습니다.
  - 결제완료 -> 상품 준비중 변경으로 일괄처리 가능
  - 상품 준비중 -> 출고 대기 변경으로 일괄처리 가능
  - 출고 대기 변경시, 출고 객체 생성

[KAN-497]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ