### PR TITLE
KAN-504 refactor: 합포장 영속계층 수정

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/combinedpackaging/entity/Packaging.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/combinedpackaging/entity/Packaging.java
@@ -1,6 +1,7 @@
 package com.yeonieum.orderservice.domain.combinedpackaging.entity;
 
 import com.yeonieum.orderservice.domain.delivery.entity.Delivery;
+import com.yeonieum.orderservice.domain.order.entity.OrderDetail;
 import com.yeonieum.orderservice.domain.release.entity.Release;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,17 +11,21 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "combined_packaging")
-public class CombinedPackaging {
+@Table(name = "packaging")
+public class Packaging {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "combined_packaging_id")
-    private Long combinedPackagingId;
+    @Column(name = "packaging_id")
+    private Long PackagingId;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "release_id", nullable = false)
     private Release release;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_detail_id", nullable = false)
+    private OrderDetail orderDetail;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "delivery_id", nullable = false)

--- a/src/main/java/com/yeonieum/orderservice/domain/combinedpackaging/repository/CombinedPackagingRepository.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/combinedpackaging/repository/CombinedPackagingRepository.java
@@ -1,9 +1,0 @@
-package com.yeonieum.orderservice.domain.combinedpackaging.repository;
-
-import com.yeonieum.orderservice.domain.combinedpackaging.entity.CombinedPackaging;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CombinedPackagingRepository extends JpaRepository<CombinedPackaging, Long> {
-
-
-}

--- a/src/main/java/com/yeonieum/orderservice/domain/combinedpackaging/repository/PackagingRepository.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/combinedpackaging/repository/PackagingRepository.java
@@ -1,0 +1,7 @@
+package com.yeonieum.orderservice.domain.combinedpackaging.repository;
+
+import com.yeonieum.orderservice.domain.combinedpackaging.entity.Packaging;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PackagingRepository extends JpaRepository<Packaging, Long> {
+}

--- a/src/main/java/com/yeonieum/orderservice/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/delivery/entity/Delivery.java
@@ -1,6 +1,6 @@
 package com.yeonieum.orderservice.domain.delivery.entity;
 
-import com.yeonieum.orderservice.domain.combinedpackaging.entity.CombinedPackaging;
+import com.yeonieum.orderservice.domain.combinedpackaging.entity.Packaging;
 import com.yeonieum.orderservice.domain.order.entity.OrderDetail;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,6 +34,6 @@ public class Delivery {
 
     @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private List<CombinedPackaging> combinedPackagingList = new ArrayList<>();
+    private List<Packaging> packagingList = new ArrayList<>();
 }
 

--- a/src/main/java/com/yeonieum/orderservice/domain/release/entity/Release.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/release/entity/Release.java
@@ -1,6 +1,5 @@
 package com.yeonieum.orderservice.domain.release.entity;
 
-import com.yeonieum.orderservice.domain.combinedpackaging.entity.CombinedPackaging;
 import com.yeonieum.orderservice.domain.order.entity.OrderDetail;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,10 +22,6 @@ public class Release {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_detail_id", nullable = false)
     private OrderDetail orderDetail;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "combined_packaging_id")
-    private CombinedPackaging combinedPackaging;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "release_status_id", nullable = false)


### PR DESCRIPTION
[![KAN-504](https://badgen.net/badge/JIRA/KAN-504/blue?icon=jira)](https://jira.company.com/browse/KAN-504) [![PR-38](https://badgen.net/badge/Preview/PR-38/blue)](https://pr-38.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 합포장 영속계층 수정

## #️⃣관련 이슈

- Close#{504}

## 📝세부 작업 내용

- [x] 합포장 영속계층 -> 포장 영속계층으로 변경

## 💬참고 사항

- 문제점

1. 합포장 엔티티 생성함으로써, 주문과 배송의 관계과 일대일이 될 수 없다는 문제가 발생하였습니다.

2. 합포장시, 여러주문내역은 하나의 배송관계를 가져야했지만, 기존의 로직은 주문내역은 단 하나의 배송객체만을 가져야하여 수정하였습니다.

- 해결방안

1. 포장이라는 엔티티를 만들어 출고ID, 배송ID, 주문ID를 가짐으로써, 여러 포장들은 하나의 배송을 바라보게 하였습니다.

[KAN-504]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ