### PR TITLE
KAN-621 fix : 주문상태 변경 시 문자 알림 로직 수정

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/notification/service/OrderNotificationServiceForMember.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/notification/service/OrderNotificationServiceForMember.java
@@ -35,9 +35,10 @@ public class OrderNotificationServiceForMember {
     public void sendOrderMessage(OrderNotificationMessage orderNotificationMessage) throws NurigoMessageNotReceivedException, NurigoEmptyResponseException, NurigoUnknownException {
         Message message = new Message();
         message.setFrom("01089387607");
-        message.setTo(orderNotificationMessage.getPhoneNumber().replaceAll("-", ""));
+        //message.setTo(orderNotificationMessage.getPhoneNumber().replaceAll("-", ""));
+        message.setTo("01089387607");
         String text = MessageBuilder.createOrderMessage(orderNotificationMessage);
-        message.setText(text);
+        message.setText("[연이음 주문 안내]\n\n" + text);
 
         defaultMessageService.send(message);
     }
@@ -48,7 +49,7 @@ public class OrderNotificationServiceForMember {
         Message message = new Message();
         message.setFrom("01089387607");
         message.setTo(regularOrderNotificationMessage.getPhoneNumber());
-
+        //message.setTo("01089387607");
         String text = "";
         switch (regularOrderNotificationMessage.getEventType()) {
             case "APPLY" -> {

--- a/src/main/java/com/yeonieum/orderservice/infrastructure/feignclient/ProductServiceFeignClient.java
+++ b/src/main/java/com/yeonieum/orderservice/infrastructure/feignclient/ProductServiceFeignClient.java
@@ -20,19 +20,19 @@ public interface ProductServiceFeignClient {
     ResponseEntity<StockUsageResponse.AvailableResponseList> checkAvailableOrderProduct(@RequestBody StockUsageRequest.IncreaseStockUsageList increaseStockUsageDtoList);
 
     @GetMapping("/api/management/{productId}")
-    ResponseEntity<ApiResponse<RegularOrderResponse.ProductOrder>> retrieveProductInformation(@PathVariable Long productId);
+    ResponseEntity<ApiResponse<RegularOrderResponse.ProductOrder>> retrieveProductInformation(@PathVariable("productId") Long productId);
 
     @GetMapping("/api/management/products")
     ResponseEntity<ApiResponse<Map<Long, RegularOrderResponse.ProductOrder>>> bulkRetrieveProductInformation(@RequestParam List<Long> productIdList);
 
-    @GetMapping("/api/shopping/product/order/{productId}")
-    public ResponseEntity<ApiResponse<RetrieveOrderInformationResponse>> retrieveOrderProductInformation(@PathVariable Long productIdList);
+    @GetMapping("/api/shopping/product/order/{productIdList}")
+    public ResponseEntity<ApiResponse<RetrieveOrderInformationResponse>> retrieveOrderProductInformation(@PathVariable("productIdList") Long productIdList);
     
     @GetMapping("/api/shopping/product/orders/{productIdList}")
-    public ResponseEntity<ApiResponse<List<RetrieveOrderInformationResponse>>> retrieveOrderProductInformation(@PathVariable List<Long> productIdList);
+    public ResponseEntity<ApiResponse<List<RetrieveOrderInformationResponse>>> retrieveOrderProductInformation(@PathVariable("productIdList") List<Long> productIdList);
 
     @GetMapping("/api/customer/delivery-fee/{customerId}")
-    ResponseEntity<ApiResponse<Integer>> retrieveDeliveryFee(@PathVariable Long customerId);
+    ResponseEntity<ApiResponse<Integer>> retrieveDeliveryFee(@PathVariable("customerId") Long customerId);
 
 }
 


### PR DESCRIPTION
[![KAN-621](https://badgen.net/badge/JIRA/KAN-621/blue?icon=jira)](https://jira.company.com/browse/KAN-621) [![PR-75](https://badgen.net/badge/Preview/PR-75/blue)](https://pr-75.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 주문상태 변경 시 문자 알림 로직 수정

## #️⃣관련 이슈

- Close#{621}

## 📝세부 작업 내용

- [x] 주문상태 변경 시 문자 알림 로직 수정

## 💬참고 사항

[KAN-621]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ