### PR TITLE
KAN-627 feat: 출고조회 로직 수정

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/order/dto/request/OrderRequest.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/order/dto/request/OrderRequest.java
@@ -42,7 +42,6 @@ public class OrderRequest {
         OrderStatusCode orderStatusCode;
     }
 
-
     @Getter
     @NoArgsConstructor
     public static class OfCreation {
@@ -57,7 +56,6 @@ public class OrderRequest {
         int deliveryFee;
         String orderMemo;
         private int paymentCardId;
-        //PaymentCard paymentCard;
 
         public OrderDetail toOrderDetailEntity(String memberId,OrderStatus orderStatus, String orderDetailId) {
             return OrderDetail.builder()

--- a/src/main/java/com/yeonieum/orderservice/domain/regularorder/dto/request/RegularOrderRequest.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/regularorder/dto/request/RegularOrderRequest.java
@@ -25,7 +25,6 @@ public class RegularOrderRequest {
         Long productId;
     }
 
-
     @Getter
     @NoArgsConstructor
     public static class OfCreation {

--- a/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryCustom.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryCustom.java
@@ -6,7 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface ReleaseRepositoryCustom {
-    Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId,LocalDate startDate, LocalDate endDate, Pageable pageable);
+    Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable);
 }

--- a/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryImpl.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryImpl.java
@@ -21,7 +21,7 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, LocalDate startDate, LocalDate endDate, Pageable pageable) {
+    public Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable) {
         QRelease release = QRelease.release;
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -46,8 +46,8 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
         if (recipientAddress != null) {
             builder.and(release.orderDetail.deliveryAddress.eq(recipientAddress));
         }
-        if (memberId != null) {
-            builder.and(release.orderDetail.memberId.eq(memberId));
+        if (memberIds != null && !memberIds.isEmpty()) {
+            builder.and(release.orderDetail.memberId.in(memberIds));
         }
         if (startDate != null) {
             builder.and(release.createdDate.goe(startDate));

--- a/src/main/java/com/yeonieum/orderservice/global/exceptions/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/yeonieum/orderservice/global/exceptions/handler/GlobalExceptionHandler.java
@@ -2,9 +2,15 @@ package com.yeonieum.orderservice.global.exceptions.handler;
 
 import com.yeonieum.orderservice.global.exceptions.exception.CustomException;
 import com.yeonieum.orderservice.global.responses.ErrorResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -16,4 +22,15 @@ public class GlobalExceptionHandler {
                 .exception(e)
                 .build(), e.getStatus());
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        Map<String , String> errorMap = new HashMap<>();
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            errorMap.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        return new ResponseEntity<>(ErrorResponse.of(errorMap, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
+    }
 }
+

--- a/src/main/java/com/yeonieum/orderservice/global/responses/ErrorResponse.java
+++ b/src/main/java/com/yeonieum/orderservice/global/responses/ErrorResponse.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor
 public class ErrorResponse {
     private LocalDateTime timestamp;
+    private Map<String, String> errors;
     private int exceptionCode;
     private String exceptionMessage;
     private HttpStatus status;
@@ -22,5 +24,16 @@ public class ErrorResponse {
         this.exceptionMessage = exception.getCustomCode().getMessage();
         this.exceptionCode = exception.getCustomCode().getCode();
         this.status = exception.getStatus();
+    }
+
+    @Builder
+    protected ErrorResponse(Map<String, String> errors, HttpStatus status) {
+        this.timestamp = LocalDateTime.now();
+        this.errors = errors;
+        this.status = status;
+    }
+
+    public static ErrorResponse of(Map<String, String> errors, HttpStatus status) {
+        return new ErrorResponse(errors, status);
     }
 }

--- a/src/main/java/com/yeonieum/orderservice/infrastructure/feignclient/MemberServiceFeignClient.java
+++ b/src/main/java/com/yeonieum/orderservice/infrastructure/feignclient/MemberServiceFeignClient.java
@@ -10,8 +10,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @FeignClient(name = "memberservice", url = "http://localhost:8010", configuration = FeignConfig.class)
 public interface MemberServiceFeignClient {
+
+    @GetMapping("/api/member/summaries")
+    ResponseEntity<ApiResponse<List<OrderResponse.MemberInfo>>> getOrderMemberInfos(@RequestParam List<String> memberIds);
+
+    @GetMapping("/api/member/filter")
+    ResponseEntity<ApiResponse<List<String>>> getOrderMemberFilter(@RequestParam(required = false) String memberName, @RequestParam(required = false) String memberPhoneNumber);
 
     @GetMapping("/api/member/order")
     ResponseEntity<ApiResponse<OrderResponse.MemberInfo>> getOrderMemberInfo(@RequestParam String memberId);

--- a/src/main/java/com/yeonieum/orderservice/web/controller/ReleaseController.java
+++ b/src/main/java/com/yeonieum/orderservice/web/controller/ReleaseController.java
@@ -46,7 +46,7 @@ public class ReleaseController {
                                                           @RequestParam(required = false, defaultValue = "0") int page,
                                                           @RequestParam(required = false, defaultValue = "10") int size) {
         return new ResponseEntity<>(ApiResponse.builder()
-                .result(releaseService.getReleaseDetailsByCustomerAndStatus(customerId, releaseStatus, orderId, startDeliveryDate, recipient, recipientPhoneNumber, recipientAddress, memberId, memberName, memberPhoneNumber, startDate, endDate, PageRequest.of(page, size)))
+                .result(releaseService.getReleaseDetailsByFilteredMembers(customerId, releaseStatus, orderId, startDeliveryDate, recipient, recipientPhoneNumber, recipientAddress, memberId, memberName, memberPhoneNumber, startDate, endDate, PageRequest.of(page, size)))
                 .successCode(SuccessCode.SELECT_SUCCESS)
                 .build(), HttpStatus.OK);
     }


### PR DESCRIPTION
[![KAN-627](https://badgen.net/badge/JIRA/KAN-627/blue?icon=jira)](https://jira.company.com/browse/KAN-627) [![PR-79](https://badgen.net/badge/Preview/PR-79/blue)](https://pr-79.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 출고조회 로직 수정

## #️⃣관련 이슈

- Close#{627}

## 📝세부 작업 내용

- [x] 출고 조회시, feignclient로 받아오는 회원정보 필터링 문제 해결

## 💬참고 사항
- 기존의 로직
  - feignclient로 받아오는 회원정보는 페이지네이션이 적용된 데이터에서 필터링을 적용하고 있었음
  - 문제) 전체 데이터에서 회원데이터를 필터링하지 못 함
  
- 해결방법
  - 회원정보로 필터링 될 시, 멤버서비스에서 회원이름, 회원 휴대전화로 필터링 된 회원 ID들을 받아옴
  - 출고 서비스에서 필터링 된 회원들의 정보와 기존의 출고데이터를 결합하여 해결

[KAN-627]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ