### PR TITLE
KAN-642 hotfix : 일반 주문 상세 조회 - orderMemo 추가, 정기 주문 상세 조회 - storeName,…

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/order/dto/response/OrderResponse.java
@@ -86,6 +86,7 @@ public class OrderResponse {
         String storeName = null;
         String status;
         String image;
+        String orderMemo;
         ProductOrderList productOrderList;
         @Builder.Default
         boolean isAvailableProductInformation = true;
@@ -110,6 +111,7 @@ public class OrderResponse {
                     .orderDate(orderDetail.getOrderDateTime())
                     .status(orderDetail.getOrderStatus().getStatusName().getCode())
                     .storeName(storeName)
+                    .orderMemo(orderDetail.getOrderMemo())
                     .isAvailableProductInformation(isAvailableProductInformation)
                     .build();
         }

--- a/src/main/java/com/yeonieum/orderservice/domain/regularorder/dto/response/RegularOrderResponse.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/regularorder/dto/response/RegularOrderResponse.java
@@ -48,6 +48,8 @@ public class RegularOrderResponse {
         String regularDeliveryStatus;
         String orderMemo;
         String storeName;
+        String status;
+        int paymentAmount;
         boolean isAvailableProductService;
 
         public static OfRetrieveDetails convertedBy(RegularDeliveryApplication application,
@@ -69,7 +71,9 @@ public class RegularOrderResponse {
                     .orderMemo(application.getOrderMemo())
                     .regularDeliveryStatus(application.getRegularDeliveryStatus().getStatusName())
                     .storeName(storeName)
+                    .status(application.getRegularDeliveryStatus().getStatusName())
                     .isAvailableProductService(isAvailableProductService)
+                    .paymentAmount(orderList.getProductOrderList().stream().map(ProductOrder::getFinalPrice).reduce(0, Integer::sum))
                     .build();
         }
     }

--- a/src/main/java/com/yeonieum/orderservice/domain/regularorder/service/RegularOrderService.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/regularorder/service/RegularOrderService.java
@@ -193,6 +193,8 @@ public class RegularOrderService {
         application.getRegularDeliveryReservationList().stream().forEach(reservation -> {
             finalProductOrderMap.get(reservation.getProductId()).changeProductAmount(reservation.getQuantity());
         });
+
+
         return RegularOrderResponse.OfRetrieveDetails.convertedBy(application, productOrderMap, isAvailableProductService);
     }
 

--- a/src/main/java/com/yeonieum/orderservice/web/controller/OrderDetailController.java
+++ b/src/main/java/com/yeonieum/orderservice/web/controller/OrderDetailController.java
@@ -174,7 +174,7 @@ public class OrderDetailController {
         }
 
         return new ResponseEntity<>(ApiResponse.builder()
-                .result(resultPlaceOrder.getPaymentAmount())
+                .result(resultPlaceOrder)
                 .successCode(SuccessCode.UPDATE_SUCCESS)
                 .build(), HttpStatus.OK);
     }


### PR DESCRIPTION
[![KAN-642](https://badgen.net/badge/JIRA/KAN-642/blue?icon=jira)](https://jira.company.com/browse/KAN-642) [![PR-84](https://badgen.net/badge/Preview/PR-84/blue)](https://pr-84.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… orderMemo, status(진행중인지), 월 결제 금액 추가, 주문완료시 주문완료데이터 추가(주문번호, 결제금액 등)

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 주문 및 정기주문, 주문완료 응답 수정

## #️⃣관련 이슈

- Close#{642}

## 📝세부 작업 내용

- [x] 일반 주문 상세 조회 - orderMemo
- [x] 정기 주문 상세 조회 - storeName, orderMemo, status(진행중인지), 월 결제 금액
- [x] 주문완료시 주문번호와 총 결제금액 응답
- [ ] 
## 💬참고 사항

[KAN-642]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ