### PR TITLE
KAN-641 feat: 주문조회 로직 변경

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/order/repository/OrderDetailRepositoryCustom.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/order/repository/OrderDetailRepositoryCustom.java
@@ -7,7 +7,8 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface OrderDetailRepositoryCustom {
-    Page<OrderDetail> findOrders(Long customerId, OrderStatusCode orderStatusCode, String orderDetailId, LocalDateTime orderDateTime, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, LocalDate startDate, LocalDate endDate, Pageable pageable);
+    Page<OrderDetail> findOrders(Long customerId, OrderStatusCode orderStatusCode, String orderDetailId, LocalDateTime orderDateTime, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable);
 }

--- a/src/main/java/com/yeonieum/orderservice/domain/order/repository/OrderDetailRepositoryImpl.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/order/repository/OrderDetailRepositoryImpl.java
@@ -22,7 +22,7 @@ public class OrderDetailRepositoryImpl implements OrderDetailRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<OrderDetail> findOrders(Long customerId, OrderStatusCode orderStatusCode, String orderDetailId, LocalDateTime orderDateTime, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, LocalDate startDate, LocalDate endDate, Pageable pageable) {
+    public Page<OrderDetail> findOrders(Long customerId, OrderStatusCode orderStatusCode, String orderDetailId, LocalDateTime orderDateTime, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable) {
         QOrderDetail orderDetail = QOrderDetail.orderDetail;
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -33,22 +33,25 @@ public class OrderDetailRepositoryImpl implements OrderDetailRepositoryCustom {
             builder.and(orderDetail.orderStatus.statusName.eq(orderStatusCode));
         }
         if (orderDetailId != null) {
-            builder.and(orderDetail.orderDetailId.eq(orderDetailId));
+            builder.and(orderDetail.orderDetailId.contains(orderDetailId));
         }
         if (orderDateTime != null) {
             builder.and(orderDetail.orderDateTime.eq(orderDateTime));
         }
         if (recipient != null) {
-            builder.and(orderDetail.recipient.eq(recipient));
+            builder.and(orderDetail.recipient.contains(recipient));
         }
         if (recipientPhoneNumber != null) {
-            builder.and(orderDetail.recipientPhoneNumber.eq(recipientPhoneNumber));
+            builder.and(orderDetail.recipientPhoneNumber.contains(recipientPhoneNumber));
         }
         if (recipientAddress != null) {
-            builder.and(orderDetail.deliveryAddress.eq(recipientAddress));
+            builder.and(orderDetail.deliveryAddress.contains(recipientAddress));
         }
         if (memberId != null) {
-            builder.and(orderDetail.memberId.eq(memberId));
+            builder.and(orderDetail.memberId.contains(memberId));
+        }
+        if (memberIds != null && !memberIds.isEmpty()) {
+            builder.and(orderDetail.memberId.in(memberIds));
         }
         if (startDate != null) {
             builder.and(orderDetail.createdDate.goe(startDate));

--- a/src/main/java/com/yeonieum/orderservice/domain/order/service/OrderTrackingService.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/order/service/OrderTrackingService.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
 public class OrderTrackingService {
     private final OrderDetailRepository orderDetailRepository;
     private final OrderStatusRepository orderStatusRepository;
-    private final MemberServiceFeignClient memberFeignClient;
+    private final MemberServiceFeignClient memberServiceFeignClient;
     private final ProductServiceFeignClient productServiceFeignClient;
 
     /**
@@ -43,8 +44,19 @@ public class OrderTrackingService {
      */
     @Transactional(readOnly = true)
     public Page<OrderResponse.OfRetrieveForCustomer> retrieveOrdersForCustomer(Long customerId, OrderStatusCode orderStatusCode, String orderDetailId, LocalDateTime orderDateTime, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, String memberName, String memberPhoneNumber, LocalDate startDate, LocalDate endDate, Pageable pageable) {
-        Page<OrderDetail> orderDetailsPage =
-                orderDetailRepository.findOrders(customerId, orderStatusCode, orderDetailId, orderDateTime, recipient, recipientPhoneNumber, recipientAddress, memberId, startDate, endDate, pageable);
+
+        List<String> filteredMemberIds = null;
+
+        if (memberName != null || memberPhoneNumber != null) {
+            // 멤버 이름과 전화번호로 필터링하여 필요한 멤버 ID들을 먼저 수집
+            filteredMemberIds = memberServiceFeignClient.getOrderMemberFilter(memberName, memberPhoneNumber).getBody().getResult();
+            if (filteredMemberIds.isEmpty()) {
+                // 필터링된 멤버 ID가 없으면 비어 있는 페이지 반환
+                return Page.empty(pageable);
+            }
+        }
+
+        Page<OrderDetail> orderDetailsPage = orderDetailRepository.findOrders(customerId, orderStatusCode, orderDetailId, orderDateTime, recipient, recipientPhoneNumber, recipientAddress, memberId, filteredMemberIds, startDate, endDate, pageable);
 
         List<OrderResponse.OfRetrieveForCustomer> convertedOrders = new ArrayList<>();
         List<Long> productIdList = orderDetailsPage.stream()
@@ -68,37 +80,32 @@ public class OrderTrackingService {
         for (OrderDetail orderDetail : orderDetailsPage) {
             boolean isAvailableMemberService = true;
             try{
-                memberResponse = memberFeignClient.getOrderMemberInfo(orderDetail.getMemberId());
+                memberResponse = memberServiceFeignClient.getOrderMemberInfo(orderDetail.getMemberId());
             } catch (FeignException e) {
                 isAvailableMemberService = false;
             }
             OrderResponse.MemberInfo memberInfo = memberResponse == null ? null : memberResponse.getBody().getResult();
 
-            // 필터링 조건을 확인하여 필요한 경우 필터링
-            if (memberInfo != null &&
-                    (memberName == null || memberName.equals(memberInfo.getMemberName())) &&
-                    (memberPhoneNumber == null || memberPhoneNumber.equals(memberInfo.getMemberPhoneNumber()))) {
+            OrderResponse.OfRetrieveForCustomer orderResponse =
+                    OrderResponse.OfRetrieveForCustomer.convertedBy(orderDetail, memberInfo, isAvailableProductService, isAvailableMemberService);
 
-                OrderResponse.OfRetrieveForCustomer orderResponse =
-                        OrderResponse.OfRetrieveForCustomer.convertedBy(orderDetail, memberInfo, isAvailableProductService, isAvailableMemberService);
+            if(isAvailableProductService) {
+                List<RetrieveOrderInformationResponse> productInformation = productResponse.getBody().getResult();
+                final Map<Long, RetrieveOrderInformationResponse> productInformationMap =
+                        productInformation.stream().collect(Collectors.toMap(RetrieveOrderInformationResponse::getProductId, product -> product));
 
-                if(isAvailableProductService) {
-                    List<RetrieveOrderInformationResponse> productInformation = productResponse.getBody().getResult();
-                    final Map<Long, RetrieveOrderInformationResponse> productInformationMap =
-                            productInformation.stream().collect(Collectors.toMap(RetrieveOrderInformationResponse::getProductId, product -> product));
-
-                    orderResponse.getProductOrderList().getProductOrderList().stream().map(
-                            productOrder -> {
-                                productOrder.changeName(productInformationMap.get(productOrder.getProductId()).getProductName());
-                                return productOrder;
-                            }).collect(Collectors.toList());
-                }
-                convertedOrders.add(orderResponse);
+                orderResponse.getProductOrderList().getProductOrderList().stream().map(
+                        productOrder -> {
+                            productOrder.changeName(productInformationMap.get(productOrder.getProductId()).getProductName());
+                            return productOrder;
+                        }).collect(Collectors.toList());
             }
+            convertedOrders.add(orderResponse);
         }
 
         return new PageImpl<>(convertedOrders, pageable, orderDetailsPage.getTotalElements());
     }
+
 
     /**
      * 고객용 주문상태별 주문 건수 조회 서비스

--- a/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryCustom.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface ReleaseRepositoryCustom {
-    Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable);
+    Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable);
 }

--- a/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryImpl.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/release/repository/ReleaseRepositoryImpl.java
@@ -21,7 +21,7 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable) {
+    public Page<Release> findReleases(Long customerId, ReleaseStatusCode statusCode, String orderId, LocalDate startDeliveryDate, String recipient, String recipientPhoneNumber, String recipientAddress, String memberId, List<String> memberIds, LocalDate startDate, LocalDate endDate, Pageable pageable) {
         QRelease release = QRelease.release;
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -32,19 +32,22 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
             builder.and(release.releaseStatus.statusName.eq(statusCode));
         }
         if (orderId != null) {
-            builder.and(release.orderDetail.orderDetailId.eq(orderId));
+            builder.and(release.orderDetail.orderDetailId.contains(orderId));
         }
         if (startDeliveryDate != null) {
             builder.and(release.startDeliveryDate.eq(startDeliveryDate));
         }
         if (recipient != null) {
-            builder.and(release.orderDetail.recipient.eq(recipient));
+            builder.and(release.orderDetail.recipient.contains(recipient));
         }
         if (recipientPhoneNumber != null) {
-            builder.and(release.orderDetail.recipientPhoneNumber.eq(recipientPhoneNumber));
+            builder.and(release.orderDetail.recipientPhoneNumber.contains(recipientPhoneNumber));
         }
         if (recipientAddress != null) {
-            builder.and(release.orderDetail.deliveryAddress.eq(recipientAddress));
+            builder.and(release.orderDetail.deliveryAddress.contains(recipientAddress));
+        }
+        if (memberId != null) {
+            builder.and(release.orderDetail.memberId.contains(memberId));
         }
         if (memberIds != null && !memberIds.isEmpty()) {
             builder.and(release.orderDetail.memberId.in(memberIds));


### PR DESCRIPTION
[![KAN-641](https://badgen.net/badge/JIRA/KAN-641/blue?icon=jira)](https://jira.company.com/browse/KAN-641) [![PR-86](https://badgen.net/badge/Preview/PR-86/blue)](https://pr-86.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 주문조회 로직 변경

## #️⃣관련 이슈

- Close#{641}

## 📝세부 작업 내용

- [x] 주문조회 로직 변경

## 💬참고 사항

- 기존의 로직
  - feignclient로 받아오는 회원정보는 페이지네이션이 적용된 데이터에서 필터링을 적용하고 있었음
  - 문제) 전체 데이터에서 회원데이터를 필터링하지 못 함

- 해결방법
  - 회원정보로 필터링 될 시, 멤버서비스에서 회원이름, 회원 휴대전화로 필터링 된 회원 ID들을 받아옴
  - 주문 서비스에서 필터링 된 회원들의 정보와 기존의 주문데이터를 결합하여 해결

[KAN-641]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ