### PR TITLE
KAN-646 feat: 출고조회 로직 강화

### DIFF
--- a/src/main/java/com/yeonieum/orderservice/domain/order/service/OrderTrackingService.java
+++ b/src/main/java/com/yeonieum/orderservice/domain/order/service/OrderTrackingService.java
@@ -55,8 +55,6 @@ public class OrderTrackingService {
 
         if (memberName != null || memberPhoneNumber != null) {
             isFilteredMember = true;
-            // 멤버 이름과 전화번호로 필터링하여 필요한 멤버 ID들을 먼저 수집
-            //filteredMemberIds = memberServiceFeignClient.getOrderMemberFilter(memberName, memberPhoneNumber).getBody().getResult();
             try {
                 memberInfoMapResponse = memberServiceFeignClient.getFilterMemberMap(memberName, memberPhoneNumber);
                 if(!memberInfoMapResponse.getStatusCode().is2xxSuccessful()) {


### PR DESCRIPTION
[![KAN-646](https://badgen.net/badge/JIRA/KAN-646/blue?icon=jira)](https://jira.company.com/browse/KAN-646) [![PR-89](https://badgen.net/badge/Preview/PR-89/blue)](https://pr-89.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 출고조회 로직 강화

## #️⃣관련 이슈

- Close#{646}

## 📝세부 작업 내용

- [x] 출고조회 로직 강화

## 💬참고 사항

- feginClient통신 오류시, 기존의 출고 데이터는 조회 가능하게 하였습니다.

[KAN-646]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ